### PR TITLE
Add long value variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # zsh-osx-keychain
 
-OSX keychain utilities for secure environment vars
+macOS keychain utilities for secure environment vars
 
-So you have some values you need in your shell, but you know you shouldn't keep then in plaintext on disk.
+So you have some values you need in your shell, but you know you shouldn't keep them in plaintext on disk.
 
 ## Usage
 
@@ -12,25 +12,39 @@ So you have some values you need in your shell, but you know you shouldn't keep 
 set-keychain-environment-variable MY_SECRET_ENV
 ```
 
-You will be prompted for the value (and a confirmation)
+You will be prompted for the value (input is hidden).
 
 ```text
-password data for new item:
-retype password for new item:
+Enter value for MY_SECRET_ENV:
 ```
+
+#### Long or multiline values
+
+Use `-m` (or `--long`) to enter multiline values interactively, terminated by EOF (Ctrl-D):
+
+```sh
+set-keychain-environment-variable -m MY_LONG_SECRET
+```
+
+#### Pipe from stdin
+
+You can also pipe a value directly:
+
+```sh
+echo "my-secret-value" | set-keychain-environment-variable MY_SECRET_ENV
+cat cert.pem | set-keychain-environment-variable MY_CERT
+```
+
+#### Hex encoding
+
+Values are stored as plain text by default. If the value contains newlines, is longer than 128 characters, or the `-m`/`--long` flag is used, the value is automatically hex-encoded in the keychain. Reading transparently handles both formats. (It uses the "type" attribute in keychain to determine how to decode the value on read.)
 
 ### Read a variable
 
-To just see the value
+To just see the value, the `keychain-environment-variable` function reads the value from the keychain and prints it to stdout.
 
 ```sh
 keychain-environment-variable MY_SECRET_ENV
-```
-
-The function prints the value to stdout
-
-```text
-mysecret
 ```
 
 To assign to a variable
@@ -80,7 +94,9 @@ zinit snippet https://github.com/onyxraven/zsh-osx-keychain/blob/main/zsh-osx-ke
 
 ## How it works
 
-OSX is able to programmatically access keychain values using the `security` command. You can also see these keychain items (on your default keychain) via `Keychain Access.app`
+macOS is able to programmatically access keychain values using the `security` command. You can also see these keychain items (on your default keychain) via `Keychain Access.app`.
+
+Short values (≤128 chars, no newlines) are stored as plain text (`-w` flag, type `txts`). Longer or multiline values are hex-encoded (`-X` flag, type `hexs`) and decoded transparently on read via `xxd`.
 
 ## Inspiration / Source
 

--- a/zsh-osx-keychain.plugin.zsh
+++ b/zsh-osx-keychain.plugin.zsh
@@ -35,12 +35,14 @@ function keychain-environment-variable() {
 #   prompts for or reads the value from stdin
 function set-keychain-environment-variable() {
   local -a opts
-  # delete recognized options, dont error, store options in $opts, recognize -m and --long
-  # we simplify below and detect any options were added by checking the array length
-  zparseopts -D -E -a opts m -long
+  # remove recognized options from $@; errors on unknown flags. though, flags following the name are not handled well.
+  zparseopts -D -F -a opts m -long || {
+    print "Usage: set-keychain-environment-variable [-m|--long] NAME" >&2
+    return 1
+  }
 
   if [[ -z "$1" ]]; then
-    print "Missing environment variable name" >&2
+    print "Usage: set-keychain-environment-variable [-m|--long] NAME" >&2
     return 1
   fi
 
@@ -49,14 +51,22 @@ function set-keychain-environment-variable() {
     # if we are in a terminal, prompt
     if ((${#opts})); then
       print "Enter value for $1 (end with EOF / Ctrl-D):"
-      value=$(cat)
+      value=$(
+        cat
+        printf .
+      )
+      value=${value%.}
     else
       read -rs "value?Enter value for $1: "
       print
     fi
   else
     # get from stdin
-    value=$(cat)
+    value=$(
+      cat
+      printf .
+    )
+    value=${value%.}
   fi
 
   # if the string has newlines or is longer than 128 characters, or told multiline, use the hex encoding method

--- a/zsh-osx-keychain.plugin.zsh
+++ b/zsh-osx-keychain.plugin.zsh
@@ -1,35 +1,80 @@
-### Functions for setting and getting environment variables from the OSX keychain ###
+### Functions for setting and getting environment variables from the macOS keychain ###
 ### Adapted from https://www.netmeister.org/blog/keychain-passwords.html ###
 ### and https://gist.github.com/bmhatfield/f613c10e360b4f27033761bbee4404fd ###
+### ref: https://www.dssw.co.uk/reference/security/ ###
 
 # Use: keychain-environment-variable SECRET_ENV_VAR
-#   echos the value
+#   prints the value to stdout
 function keychain-environment-variable() {
-  if [ -z "$1" ]; then
-    print "Missing environment variable name"
+  if [[ -z "$1" ]]; then
+    print "Missing environment variable name" >&2
     return 1
   fi
 
-  security find-generic-password -w -a ${USER} -D "environment variable" -s "${1}"
+  # check that keychain item exists and what its "type"<uint32>="value" is
+  # backwards compatibility: if "type" is not set, assume it's a text string
+  local type
+  type=$(security find-generic-password -a "${USER}" -D "environment variable" -s "$1" -g 2>&1 1>/dev/null |
+    awk -F= '/"type"/{print $2}')
+
+  case "$type" in
+  '"txts"' | '""' | '"text"' | '<NULL>')
+    security find-generic-password -w -a "${USER}" -D "environment variable" -s "$1"
+    ;;
+  '"hexs"')
+    security find-generic-password -w -a "${USER}" -D "environment variable" -s "$1" | xxd -r -p
+    ;;
+  *)
+    print "No environment variable found in keychain for $1" >&2
+    return 1
+    ;;
+  esac
 }
 
-# Use: set-keychain-environment-variable SECRET_ENV_VAR
-#   security will prompt for the value
+# Use: set-keychain-environment-variable [-m|--long] SECRET_ENV_VAR
+#   prompts for or reads the value from stdin
 function set-keychain-environment-variable() {
-  if [ -z "$1" ]; then
-    print "Missing environment variable name"
+  local -a opts
+  # delete recognized options, dont error, store options in $opts, recognize -m and --long
+  # we simplify below and detect any options were added by checking the array length
+  zparseopts -D -E -a opts m -long
+
+  if [[ -z "$1" ]]; then
+    print "Missing environment variable name" >&2
     return 1
   fi
 
-  security add-generic-password -U -a ${USER} -D "environment variable" -s "${1}" -w
+  local value
+  if [[ -t 0 ]]; then
+    # if we are in a terminal, prompt
+    if ((${#opts})); then
+      print "Enter value for $1 (end with EOF / Ctrl-D):"
+      value=$(cat)
+    else
+      read -rs "value?Enter value for $1: "
+      print
+    fi
+  else
+    # get from stdin
+    value=$(cat)
+  fi
+
+  # if the string has newlines or is longer than 128 characters, or told multiline, use the hex encoding method
+  if [[ "$value" == *$'\n'* ]] || ((${#value} > 128)) || ((${#opts})); then
+    local hex
+    hex=$(printf '%s' "$value" | xxd -p | tr -d '\n')
+    security add-generic-password -U -a "${USER}" -D "environment variable" -s "$1" -X "$hex" -C "hexs"
+  else
+    security add-generic-password -U -a "${USER}" -D "environment variable" -s "$1" -w "$value" -C "txts"
+  fi
 }
 
 # Use: delete-keychain-environment-variable SECRET_ENV_VAR
 function delete-keychain-environment-variable() {
-  if [ -z "$1" ]; then
-    print "Missing environment variable name"
+  if [[ -z "$1" ]]; then
+    print "Missing environment variable name" >&2
     return 1
   fi
 
-  security delete-generic-password -a ${USER} -D "environment variable" -s "${1}"
+  security delete-generic-password -a "${USER}" -D "environment variable" -s "$1"
 }


### PR DESCRIPTION
Inspired by #2 and some other user feedback, this updates the function to transparently support long values.

The new behavior is gated by an attribute set on the keychain entries (4-character 'type'), so it is backward compatible. 

This also adds the ability to pipe/direct to stdin to set, or use the `-m` or `--long` flags to allow for a longer input (not using `read`).