### PR TITLE
fix strings decoded by security automatically

### DIFF
--- a/zsh-osx-keychain.plugin.zsh
+++ b/zsh-osx-keychain.plugin.zsh
@@ -22,7 +22,8 @@ function keychain-environment-variable() {
     security find-generic-password -w -a "${USER}" -D "environment variable" -s "$1"
     ;;
   '"hexs"')
-    security find-generic-password -w -a "${USER}" -D "environment variable" -s "$1" | xxd -r -p
+    # sentinel newline is always appended during encode to force security -w to return hex.
+    security find-generic-password -w -a "${USER}" -D "environment variable" -s "$1" | perl -e 'local $/; my $h = <STDIN>; $h =~ s/\s+\z//; my $d = pack("H*", $h); $d =~ s/\n\z//; print $d'
     ;;
   *)
     print "No environment variable found in keychain for $1" >&2
@@ -69,10 +70,17 @@ function set-keychain-environment-variable() {
     value=${value%.}
   fi
 
-  # if the string has newlines or is longer than 128 characters, or told multiline, use the hex encoding method
-  if [[ "$value" == *$'\n'* ]] || ((${#value} > 128)) || ((${#opts})); then
+  # if the string is longer than 1m characters, it doesn't work with this
+  if ((${#value} > 1000000)); then
+    print "Value is too longfor this utility" >&2
+    exit 1
+  fi
+
+  # if the string has newlines or told multiline, use the hex encoding method
+  # always append a sentinel newline so security -w returns hex (it decodes clean text otherwise)
+  if [[ "$value" == *$'\n'* ]] || ((${#opts})); then
     local hex
-    hex=$(printf '%s' "$value" | xxd -p | tr -d '\n')
+    hex=$(printf '%s\n' "$value" | perl -e 'local $/; print unpack("H*", <STDIN>)')
     security add-generic-password -U -a "${USER}" -D "environment variable" -s "$1" -X "$hex" -C "hexs"
   else
     security add-generic-password -U -a "${USER}" -D "environment variable" -s "$1" -w "$value" -C "txts"


### PR DESCRIPTION
it turns out `security`, if a value wether or not it was encoded by hex, has no newlines in it, it will be returned as plain text. this is really annoying! we need to deterministically know wether we need to encode and decode. This is a bug in the existing implementation.

So, we do the following:

If the string already has newlines in it, or we're told to make it multiline, we append a newline at the end as a forcing factor/sentinel. And then we remove it at the end.

BREAKING: This has the potential effect that if you've encoded a variable with multline before this, and expect a newline at the end, it may be stripped off.

Note there is also no practical limit to the size of a keychain variable (its the size of NSString which is like 4gb). However, there is at the shell. so I'm capping that at 1m characters. it errors at that value. Find a different method of storing values in that case.